### PR TITLE
Patch: ensure /usr/share/dr-provision is present

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,4 +1,11 @@
 ---
+- name: config | Ensure /usr/share/dr-provision exists
+  file:
+    path: /usr/share/dr-provision
+    state: directory
+    mode: "u=rwx,go=rx"
+  become: true
+
 - name: config | Configuring Digital Rebar
   template:
     src: default.yaml.j2


### PR DESCRIPTION
Currently the config task `config | Configuring Digital Rebar` fails unless `/usr/share/dr-provision` somehow already exists. This patch adds a task to create that directory with the correct permissions :)