### PR TITLE
Upgrade older installed drp version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,15 +1,15 @@
 ---
-- name: install | Checking If Digital Rebar Is Already Installed
-  stat:
-    path: "{{ digital_rebar_binary }}"
-  register: _digital_rebar_install_check
+- name: install | Check current Digital Rebar version
+  shell: "{{ digital_rebar_binary }} --version 2>&1 | grep {{digital_rebar_version}}"
+  register: _digital_rebar_version_check
+  ignore_errors: True
 
 - name: install | Downloading Digital Rebar
   get_url:
     url: "{{ digital_rebar_dl }}"
     dest: "/tmp/{{ digital_rebar_package }}"
     checksum: "sha256:{{ digital_rebar_sha256 }}"
-  when: not _digital_rebar_install_check['stat']['exists']
+  when: _digital_rebar_version_check is failed
 
 - name: install | Extracting Digital Rebar
   unarchive:
@@ -17,7 +17,7 @@
     dest: /tmp
     remote_src: true
   register: _digital_rebar_extracted
-  when: not _digital_rebar_install_check['stat']['exists']
+  when: _digital_rebar_version_check is failed
 
 - name: install | Copying Digital Rebar Packages
   copy:
@@ -31,7 +31,7 @@
     - dr-provision
     - incrementer
   when: >
-        not _digital_rebar_install_check['stat']['exists'] and
+        _digital_rebar_version_check is failed and
         _digital_rebar_extracted['changed']
 
 - name: install | Creating /var/lib/dr-provision


### PR DESCRIPTION
Currently the Ansible script only installs digital rebar when it is not present yet. This pull request tries to determine the version, if it does not match or fails to check we'll simply reinstall the new version over the old one.